### PR TITLE
Drop redundant 'const'

### DIFF
--- a/include/tclap/UnlabeledMultiArg.h
+++ b/include/tclap/UnlabeledMultiArg.h
@@ -293,7 +293,7 @@ bool UnlabeledMultiArg<T>::operator==(const Arg& a) const
 template<class T>
 void UnlabeledMultiArg<T>::addToList( std::list<Arg*>& argList ) const
 {
-	argList.push_back( const_cast<Arg*>(static_cast<const Arg* const>(this)) );
+	argList.push_back( const_cast<Arg*>(static_cast<const Arg*>(this)) );
 }
 
 }

--- a/include/tclap/UnlabeledValueArg.h
+++ b/include/tclap/UnlabeledValueArg.h
@@ -333,7 +333,7 @@ bool UnlabeledValueArg<T>::operator==(const Arg& a ) const
 template<class T>
 void UnlabeledValueArg<T>::addToList( std::list<Arg*>& argList ) const
 {
-	argList.push_back( const_cast<Arg*>(static_cast<const Arg* const>(this)) );
+	argList.push_back( const_cast<Arg*>(static_cast<const Arg*>(this)) );
 }
 
 }


### PR DESCRIPTION
This patch fixes the warning issued by intel compilers:

```
tclap/UnlabeledMultiArg.h(296): warning #191: type qualifier is meaningless on cast type
	argList.push_back( const_cast<Arg*>(static_cast<const Arg* const>(this)) );
                                                        ^
```
Fixes #2 

Change-Id: Id99c1d584cc9973e0802f9ce4de86b13be6d2253